### PR TITLE
Added checks for target and targeted being null

### DIFF
--- a/target-enhancements.js
+++ b/target-enhancements.js
@@ -333,7 +333,7 @@ class TargetEnhancements {
     static async updateTokenEventHandler(scene,token_obj,update,dif,userId) { 
         let token = canvas.tokens.get(token_obj._id);
         // console.log("Token updated:",token.icon);
-        token.target.clear();
+        token?.target?.clear();
 
         // patch for issue #11. Only fixes it for DND I think :(
         try {
@@ -341,7 +341,7 @@ class TargetEnhancements {
         } catch (error) {}
         
 
-        if (TargetEnhancements.getTargets(await token.targeted).selfA.length) {
+        if (token?.targeted && TargetEnhancements.getTargets(await token.targeted).selfA.length) {
             TargetEnhancements.drawTargetIndicators(token);
         }
     };


### PR DESCRIPTION
These were throwing a crapton of errors when you changed the token appearance by adding an effect when it was untargeted.